### PR TITLE
Wireless: fix wireless AP creation (and switching back). JB#38918

### DIFF
--- a/drivers/net/wireless/bcmdhd/dhd_linux.c
+++ b/drivers/net/wireless/bcmdhd/dhd_linux.c
@@ -4425,6 +4425,9 @@ dhd_open(struct net_device *net)
 	dhd_dbgfs_init(&dhd->pub);
 #endif
 
+	/* Clear, carrier, set when connected or AP mode. */
+	netif_carrier_off(net);
+
 	OLD_MOD_INC_USE_COUNT;
 exit:
 	if (ret)


### PR DESCRIPTION
The firmware needs to be configured in AP mode (iovar apsta -> 0)
which needs to be reset upon stopping the AP (iovar apsta -> 1). The
firmware doesn't need to be reloaded. The kernel driver needs to be
configured to dynamically switch it's op_mode. This avoids setting
op_mode from userspace. I also change "arp offloading" according to
what the upstream brcmfmac driver does.

Secondly the driver needs to tell the kernel that AP creation has
succeeded with netif_carrier_on and netif_carrier_off when stopping
the AP. This avoids the command ip link set dev wlan0 master tether
in userspace.