### PR TITLE
[binder] add extra binder interfaces. JB#43286

### DIFF
--- a/arch/arm64/configs/aosp_nile_discovery_defconfig
+++ b/arch/arm64/configs/aosp_nile_discovery_defconfig
@@ -812,3 +812,6 @@ CONFIG_SUNRPC_GSS=y
 CONFIG_CIFS=y
 CONFIG_BT_HCIVHCI=y
 
+CONFIG_ANDROID_BINDER_DEVICES="binder,vndbinder,hwbinder,puddlejumper,vndpuddlejumper"
+CONFIG_CGROUP_SCHEDTUNE=n
+

--- a/arch/arm64/configs/aosp_nile_pioneer_defconfig
+++ b/arch/arm64/configs/aosp_nile_pioneer_defconfig
@@ -815,3 +815,6 @@ CONFIG_SUNRPC_GSS=y
 CONFIG_CIFS=y
 CONFIG_BT_HCIVHCI=y
 
+CONFIG_ANDROID_BINDER_DEVICES="binder,vndbinder,hwbinder,puddlejumper,vndpuddlejumper"
+CONFIG_CGROUP_SCHEDTUNE=n
+


### PR DESCRIPTION
The names do not matter, but they need to be unique.
Also disable CONFIG_CGROUP_SCHEDTUNE.