### PR TITLE
[bluetooth] Disable bt_power rfkill. JB#43036

### DIFF
--- a/drivers/bluetooth/bluetooth-power.c
+++ b/drivers/bluetooth/bluetooth-power.c
@@ -643,8 +643,9 @@ static int bt_power_probe(struct platform_device *pdev)
 		goto free_pdata;
 	}
 
-	if (bluetooth_power_rfkill_probe(pdev) < 0)
-		goto free_pdata;
+// Mer: Disable rfkill for now
+//	if (bluetooth_power_rfkill_probe(pdev) < 0)
+//		goto free_pdata;
 
 	btpdev = pdev;
 


### PR DESCRIPTION
This prevents issues with rfkill and Android blob when using bluebinder.