### PR TITLE
Cherry-pick patches required for newer qcacld kernel module. JB#44057

### DIFF
--- a/arch/arm64/configs/aosp_nile_discovery_defconfig
+++ b/arch/arm64/configs/aosp_nile_discovery_defconfig
@@ -814,3 +814,5 @@ CONFIG_BT_HCIVHCI=y
 CONFIG_ANDROID_BINDER_DEVICES="binder,vndbinder,hwbinder,puddlejumper,vndpuddlejumper"
 CONFIG_CGROUP_SCHEDTUNE=n
 
+CONFIG_WLAN_TX_FLOW_CONTROL_V2=y
+

--- a/arch/arm64/configs/aosp_nile_pioneer_defconfig
+++ b/arch/arm64/configs/aosp_nile_pioneer_defconfig
@@ -814,3 +814,5 @@ CONFIG_BT_HCIVHCI=y
 CONFIG_ANDROID_BINDER_DEVICES="binder,vndbinder,hwbinder,puddlejumper,vndpuddlejumper"
 CONFIG_CGROUP_SCHEDTUNE=n
 
+CONFIG_WLAN_TX_FLOW_CONTROL_V2=y
+

--- a/arch/arm64/configs/aosp_nile_voyager_defconfig
+++ b/arch/arm64/configs/aosp_nile_voyager_defconfig
@@ -814,3 +814,5 @@ CONFIG_BT_HCIVHCI=y
 CONFIG_ANDROID_BINDER_DEVICES="binder,vndbinder,hwbinder,puddlejumper,vndpuddlejumper"
 CONFIG_CGROUP_SCHEDTUNE=n
 
+CONFIG_WLAN_TX_FLOW_CONTROL_V2=y
+

--- a/drivers/soc/qcom/icnss.c
+++ b/drivers/soc/qcom/icnss.c
@@ -296,6 +296,7 @@ enum icnss_driver_state {
 	ICNSS_HOST_TRIGGERED_PDR,
 	ICNSS_FW_DOWN,
 	ICNSS_DRIVER_UNLOADING,
+	ICNSS_REJUVENATE,
 };
 
 struct ce_irq_list {
@@ -1175,6 +1176,14 @@ bool icnss_is_fw_down(void)
 }
 EXPORT_SYMBOL(icnss_is_fw_down);
 
+bool icnss_is_rejuvenate(void)
+{
+	if (!penv)
+		return false;
+	else
+		return test_bit(ICNSS_REJUVENATE, &penv->state);
+}
+EXPORT_SYMBOL(icnss_is_rejuvenate);
 
 int icnss_power_off(struct device *dev)
 {
@@ -1995,6 +2004,7 @@ static void icnss_qmi_wlfw_clnt_ind(struct qmi_handle *handle,
 		event_data->crashed = true;
 		event_data->fw_rejuvenate = true;
 		fw_down_data.crashed = true;
+		set_bit(ICNSS_REJUVENATE, &penv->state);
 		icnss_call_driver_uevent(penv, ICNSS_UEVENT_FW_DOWN,
 					 &fw_down_data);
 		icnss_driver_event_post(ICNSS_DRIVER_EVENT_PD_SERVICE_DOWN,
@@ -2172,6 +2182,7 @@ static int icnss_pd_restart_complete(struct icnss_priv *priv)
 
 	icnss_call_driver_shutdown(priv);
 
+	clear_bit(ICNSS_REJUVENATE, &penv->state);
 	clear_bit(ICNSS_PD_RESTART, &priv->state);
 
 	if (!priv->ops || !priv->ops->reinit)
@@ -3841,6 +3852,9 @@ static int icnss_stats_show_state(struct seq_file *s, struct icnss_priv *priv)
 			continue;
 		case ICNSS_FW_DOWN:
 			seq_puts(s, "FW DOWN");
+			continue;
+		case ICNSS_REJUVENATE:
+			seq_puts(s, "FW REJUVENATE");
 			continue;
 		case ICNSS_DRIVER_UNLOADING:
 			seq_puts(s, "DRIVER UNLOADING");

--- a/include/net/cnss_utils.h
+++ b/include/net/cnss_utils.h
@@ -33,6 +33,9 @@ extern int cnss_utils_get_driver_load_cnt(struct device *dev);
 extern void cnss_utils_increment_driver_load_cnt(struct device *dev);
 extern int cnss_utils_set_wlan_mac_address(const u8 *in, uint32_t len);
 extern u8 *cnss_utils_get_wlan_mac_address(struct device *dev, uint32_t *num);
+extern int cnss_utils_set_wlan_derived_mac_address(const u8 *in, uint32_t len);
+extern u8 *cnss_utils_get_wlan_derived_mac_address(struct device *dev,
+							uint32_t *num);
 extern void cnss_utils_set_cc_source(struct device *dev,
 				     enum cnss_utils_cc_src cc_source);
 extern enum cnss_utils_cc_src cnss_utils_get_cc_source(struct device *dev);

--- a/include/soc/qcom/icnss.h
+++ b/include/soc/qcom/icnss.h
@@ -13,9 +13,14 @@
 #define _ICNSS_WLAN_H_
 
 #include <linux/interrupt.h>
+#include <linux/device.h>
 
 #define ICNSS_MAX_IRQ_REGISTRATIONS    12
 #define ICNSS_MAX_TIMESTAMP_LEN        32
+
+#ifndef ICNSS_API_WITH_DEV
+#define ICNSS_API_WITH_DEV
+#endif
 
 enum icnss_uevent {
 	ICNSS_UEVENT_FW_READY,
@@ -40,6 +45,8 @@ struct icnss_uevent_data {
 
 struct icnss_driver_ops {
 	char *name;
+	unsigned long drv_state;
+	struct device_driver driver;
 	int (*probe)(struct device *dev);
 	void (*remove)(struct device *dev);
 	void (*shutdown)(struct device *dev);
@@ -105,28 +112,34 @@ struct icnss_soc_info {
 	char fw_build_timestamp[ICNSS_MAX_TIMESTAMP_LEN + 1];
 };
 
-extern int icnss_register_driver(struct icnss_driver_ops *driver);
-extern int icnss_unregister_driver(struct icnss_driver_ops *driver);
-extern int icnss_wlan_enable(struct icnss_wlan_enable_cfg *config,
+#define icnss_register_driver(ops)		\
+	__icnss_register_driver(ops, THIS_MODULE, KBUILD_MODNAME)
+extern int __icnss_register_driver(struct icnss_driver_ops *ops,
+				   struct module *owner, const char *mod_name);
+
+extern int icnss_unregister_driver(struct icnss_driver_ops *ops);
+
+extern int icnss_wlan_enable(struct device *dev,
+			     struct icnss_wlan_enable_cfg *config,
 			     enum icnss_driver_mode mode,
 			     const char *host_version);
-extern int icnss_wlan_disable(enum icnss_driver_mode mode);
-extern void icnss_enable_irq(unsigned int ce_id);
-extern void icnss_disable_irq(unsigned int ce_id);
-extern int icnss_get_soc_info(struct icnss_soc_info *info);
-extern int icnss_ce_free_irq(unsigned int ce_id, void *ctx);
-extern int icnss_ce_request_irq(unsigned int ce_id,
+extern int icnss_wlan_disable(struct device *dev, enum icnss_driver_mode mode);
+extern void icnss_enable_irq(struct device *dev, unsigned int ce_id);
+extern void icnss_disable_irq(struct device *dev, unsigned int ce_id);
+extern int icnss_get_soc_info(struct device *dev, struct icnss_soc_info *info);
+extern int icnss_ce_free_irq(struct device *dev, unsigned int ce_id, void *ctx);
+extern int icnss_ce_request_irq(struct device *dev, unsigned int ce_id,
 	irqreturn_t (*handler)(int, void *),
 	unsigned long flags, const char *name, void *ctx);
-extern int icnss_get_ce_id(int irq);
-extern int icnss_set_fw_log_mode(uint8_t fw_log_mode);
+extern int icnss_get_ce_id(struct device *dev, int irq);
+extern int icnss_set_fw_log_mode(struct device *dev, uint8_t fw_log_mode);
 extern int icnss_athdiag_read(struct device *dev, uint32_t offset,
 			      uint32_t mem_type, uint32_t data_len,
 			      uint8_t *output);
 extern int icnss_athdiag_write(struct device *dev, uint32_t offset,
 			       uint32_t mem_type, uint32_t data_len,
 			       uint8_t *input);
-extern int icnss_get_irq(int ce_id);
+extern int icnss_get_irq(struct device *dev, int ce_id);
 extern int icnss_power_on(struct device *dev);
 extern int icnss_power_off(struct device *dev);
 extern struct dma_iommu_mapping *icnss_smmu_get_mapping(struct device *dev);
@@ -138,7 +151,7 @@ extern int icnss_get_wlan_unsafe_channel(u16 *unsafe_ch_list, u16 *ch_count,
 					 u16 buf_len);
 extern int icnss_wlan_set_dfs_nol(const void *info, u16 info_len);
 extern int icnss_wlan_get_dfs_nol(void *info, u16 info_len);
-extern bool icnss_is_qmi_disable(void);
+extern bool icnss_is_qmi_disable(struct device *dev);
 extern bool icnss_is_fw_ready(void);
 extern bool icnss_is_fw_down(void);
 extern int icnss_set_wlan_mac_address(const u8 *in, const uint32_t len);

--- a/include/soc/qcom/icnss.h
+++ b/include/soc/qcom/icnss.h
@@ -156,6 +156,7 @@ extern bool icnss_is_fw_ready(void);
 extern bool icnss_is_fw_down(void);
 extern int icnss_set_wlan_mac_address(const u8 *in, const uint32_t len);
 extern u8 *icnss_get_wlan_mac_address(struct device *dev, uint32_t *num);
+extern bool icnss_is_rejuvenate(void);
 extern int icnss_trigger_recovery(struct device *dev);
 extern void cnss_set_cc_source(enum cnss_cc_src cc_source);
 extern enum cnss_cc_src cnss_get_cc_source(void);

--- a/include/uapi/linux/msm_ipa.h
+++ b/include/uapi/linux/msm_ipa.h
@@ -435,6 +435,9 @@ enum ipa_ssr_event {
 	IPA_SSR_EVENT_MAX
 };
 
+// compat
+#define WLAN_FWR_SSR_BEFORE_SHUTDOWN IPA_SSR_BEFORE_SHUTDOWN
+
 #define IPA_EVENT_MAX_NUM ((int)IPA_SSR_EVENT_MAX)
 
 /**


### PR DESCRIPTION
After this we can update fw-api, qca-wifi-host-cmn and qcacld-3.0 to sony/aosp/LA.UM.7.3.r1.