### PR TITLE
Backport et51x/fpc1145: Fix unbalanced poll_wait and race conditions

### DIFF
--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -347,28 +347,20 @@ static unsigned int et51x_poll_interrupt(struct file *fp,
 	struct et51x_data *et51x = to_et51x_data(fp);
 	struct device *dev = et51x->dev;
 
+	/* Add current file to the waiting list */
+	poll_wait(fp, &et51x->irq_evt, wait);
+
 	val = et51x_get_gpio_triggered(et51x);
 	if (val) {
-		/* Early out */
-		dev_dbg(dev, "gpio already triggered\n");
+		dev_dbg(dev, "gpio triggered\n");
 		pm_wakeup_event(dev, ET51X_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
-
-	/* Add current file to the waiting list  */
-	poll_wait(fp, &et51x->irq_evt, wait);
 
 	/* Enable the irq */
 	if (et51x->irq_fired) {
 		et51x->irq_fired = false;
 		enable_irq(et51x->irq);
-	}
-
-	val = et51x_get_gpio_triggered(et51x);
-	if (val) {
-		dev_dbg(dev, "gpio triggered after poll_wait\n");
-		pm_wakeup_event(dev, ET51X_MAX_HAL_PROCESSING_TIME);
-		return POLLIN | POLLRDNORM;
 	}
 
 	/*

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -419,7 +419,7 @@ static irqreturn_t et51x_irq_handler(int irq, void *handle)
 {
 	struct et51x_data *et51x = handle;
 
-	mutex_lock(et51x->intrpoll_lock);
+	mutex_lock(&et51x->intrpoll_lock);
 
 	dev_dbg(et51x->dev, "%s: gpio=%d\n", __func__,
 			et51x_get_gpio_triggered(et51x));
@@ -430,7 +430,7 @@ static irqreturn_t et51x_irq_handler(int irq, void *handle)
 	pm_wakeup_event(et51x->dev, ET51X_MAX_HAL_PROCESSING_TIME);
 	wake_up_interruptible(&et51x->irq_evt);
 
-	mutex_unlock(et51x->intrpoll_lock);
+	mutex_unlock(&et51x->intrpoll_lock);
 
 	return IRQ_HANDLED;
 }

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -46,10 +46,12 @@
 #include <linux/mutex.h>
 #include <linux/of.h>
 #include <linux/of_gpio.h>
-#include <linux/uaccess.h>
-#include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
+#include <linux/pm_wakeup.h>
 #include <linux/poll.h>
+#include <linux/regulator/consumer.h>
+#include <linux/uaccess.h>
+
 
 #define PWR_ON_STEP_SLEEP 100
 #define PWR_ON_STEP_RANGE1 100
@@ -94,6 +96,7 @@ struct et51x_data {
 	bool irq_fired;
 	wait_queue_head_t irq_evt;
 
+	struct mutex intrpoll_lock;
 	struct mutex lock;
 	bool prepared;
 };
@@ -250,6 +253,20 @@ static int et51x_device_release(struct inode *inode, struct file *fp)
 	return 0;
 }
 
+static inline void et51x_enable_irq_if_disabled(struct et51x_data *et51x)
+{
+	mutex_lock(&et51x->intrpoll_lock);
+
+	/* Enable the irq if not enabled: */
+	if (et51x->irq_fired) {
+		et51x->irq_fired = false;
+		dev_dbg(et51x->dev, "%s: enabling irq\n", __func__);
+		enable_irq(et51x->irq);
+	}
+
+	mutex_unlock(&et51x->intrpoll_lock);
+}
+
 static long et51x_device_ioctl(struct file *fp, unsigned int cmd,
 			       unsigned long arg)
 {
@@ -308,10 +325,7 @@ static long et51x_device_ioctl(struct file *fp, unsigned int cmd,
 			return rc;
 		}
 
-		if (et51x->irq_fired) {
-			et51x->irq_fired = false;
-			enable_irq(et51x->irq);
-		}
+		et51x_enable_irq_if_disabled(et51x);
 
 		rc = wait_event_interruptible_timeout(
 			et51x->irq_evt, et51x->irq_fired,
@@ -357,18 +371,12 @@ static unsigned int et51x_poll_interrupt(struct file *fp,
 		return POLLIN | POLLRDNORM;
 	}
 
-	/* Enable the irq */
-	if (et51x->irq_fired) {
-		et51x->irq_fired = false;
-		enable_irq(et51x->irq);
-	}
-
 	/*
 	 * Nothing happened yet; make the poll wait for irq_evt.
 	 * The wakelock can be relaxed preemptively, as no processing has to
 	 * be done until the next wake-enabled IRQ fires.
 	 */
-
+	et51x_enable_irq_if_disabled(et51x);
 	pm_relax(dev);
 
 	return 0;
@@ -411,15 +419,18 @@ static irqreturn_t et51x_irq_handler(int irq, void *handle)
 {
 	struct et51x_data *et51x = handle;
 
-	int val = et51x_get_gpio_triggered(et51x);
+	mutex_lock(et51x->intrpoll_lock);
 
-	dev_dbg(et51x->dev, "%s: gpio=%d\n", __func__, val);
+	dev_dbg(et51x->dev, "%s: gpio=%d\n", __func__,
+			et51x_get_gpio_triggered(et51x));
 
 	et51x->irq_fired = true;
 
+	disable_irq_nosync(et51x->irq);
 	pm_wakeup_event(et51x->dev, ET51X_MAX_HAL_PROCESSING_TIME);
 	wake_up_interruptible(&et51x->irq_evt);
-	disable_irq_nosync(et51x->irq);
+
+	mutex_unlock(et51x->intrpoll_lock);
 
 	return IRQ_HANDLED;
 }
@@ -540,6 +551,7 @@ static int et51x_probe(struct platform_device *pdev)
 
 	irqf = IRQF_TRIGGER_LOW | IRQF_ONESHOT;
 	mutex_init(&et51x->lock);
+	mutex_init(&et51x->intrpoll_lock);
 
 	device_init_wakeup(dev, true);
 	init_waitqueue_head(&et51x->irq_evt);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -48,10 +48,11 @@
 #include <linux/mutex.h>
 #include <linux/of.h>
 #include <linux/of_gpio.h>
-#include <linux/uaccess.h>
-#include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
+#include <linux/pm_wakeup.h>
 #include <linux/poll.h>
+#include <linux/regulator/consumer.h>
+#include <linux/uaccess.h>
 
 #define FPC1145_RESET_LOW_US 1000
 #define FPC1145_RESET_HIGH1_US 100
@@ -123,6 +124,7 @@ struct fpc1145_data {
 	bool irq_fired;
 	wait_queue_head_t irq_evt;
 
+	struct mutex intrpoll_lock;
 	struct mutex lock;
 	bool prepared;
 };
@@ -325,6 +327,20 @@ static int fpc1145_device_release(struct inode *inode, struct file *fp)
 	return 0;
 }
 
+static inline void fpc1145_enable_irq_if_disabled(struct fpc1145_data *fpc1145)
+{
+	mutex_lock(&fpc1145->intrpoll_lock);
+
+	/* Enable the irq if not enabled: */
+	if (fpc1145->irq_fired) {
+		fpc1145->irq_fired = false;
+		dev_dbg(fpc1145->dev, "%s: enabling irq\n", __func__);
+		enable_irq(fpc1145->irq);
+	}
+
+	mutex_unlock(&fpc1145->intrpoll_lock);
+}
+
 static long fpc1145_device_ioctl(struct file *fp, unsigned int cmd,
 				 unsigned long arg)
 {
@@ -384,10 +400,7 @@ static long fpc1145_device_ioctl(struct file *fp, unsigned int cmd,
 			return rc;
 		}
 
-		if (fpc1145->irq_fired) {
-			fpc1145->irq_fired = false;
-			enable_irq(fpc1145->irq);
-		}
+		fpc1145_enable_irq_if_disabled(fpc1145);
 
 		rc = wait_event_interruptible_timeout(
 			fpc1145->irq_evt, fpc1145->irq_fired,
@@ -433,18 +446,12 @@ static unsigned int fpc1145_poll_interrupt(struct file *fp,
 		return POLLIN | POLLRDNORM;
 	}
 
-	/* Enable the irq */
-	if (fpc1145->irq_fired) {
-		fpc1145->irq_fired = false;
-		enable_irq(fpc1145->irq);
-	}
-
 	/*
 	 * Nothing happened yet; make the poll wait for irq_evt.
 	 * The wakelock can be relaxed preemptively, as no processing has to
 	 * be done until the next wake-enabled IRQ fires.
 	 */
-
+	fpc1145_enable_irq_if_disabled(fpc1145);
 	pm_relax(dev);
 
 	return 0;
@@ -487,15 +494,18 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 {
 	struct fpc1145_data *fpc1145 = handle;
 
-	int val = gpio_get_value(fpc1145->irq_gpio);
+	mutex_lock(&fpc1145->intrpoll_lock);
 
-	dev_dbg(fpc1145->dev, "%s: gpio=%d\n", __func__, val);
+	dev_dbg(fpc1145->dev, "%s: gpio=%d\n", __func__,
+			gpio_get_value(fpc1145->irq_gpio));
 
 	fpc1145->irq_fired = true;
 
+	disable_irq_nosync(fpc1145->irq);
 	pm_wakeup_event(fpc1145->dev, FPC_MAX_HAL_PROCESSING_TIME);
 	wake_up_interruptible(&fpc1145->irq_evt);
-	disable_irq_nosync(fpc1145->irq);
+
+	mutex_unlock(&fpc1145->intrpoll_lock);
 
 	return IRQ_HANDLED;
 }
@@ -643,6 +653,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 
 	irqf = IRQF_TRIGGER_HIGH | IRQF_ONESHOT;
 	mutex_init(&fpc1145->lock);
+	mutex_init(&fpc1145->intrpoll_lock);
 
 	device_init_wakeup(dev, true);
 	init_waitqueue_head(&fpc1145->irq_evt);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -423,28 +423,20 @@ static unsigned int fpc1145_poll_interrupt(struct file *fp,
 	struct fpc1145_data *fpc1145 = to_fpc1145_data(fp);
 	struct device *dev = fpc1145->dev;
 
+	/* Add current file to the waiting list */
+	poll_wait(fp, &fpc1145->irq_evt, wait);
+
 	val = gpio_get_value(fpc1145->irq_gpio);
 	if (val) {
-		/* Early out */
-		dev_dbg(dev, "gpio already triggered\n");
+		dev_dbg(dev, "gpio triggered\n");
 		pm_wakeup_event(dev, FPC_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
-
-	/* Add current file to the waiting list  */
-	poll_wait(fp, &fpc1145->irq_evt, wait);
 
 	/* Enable the irq */
 	if (fpc1145->irq_fired) {
 		fpc1145->irq_fired = false;
 		enable_irq(fpc1145->irq);
-	}
-
-	val = gpio_get_value(fpc1145->irq_gpio);
-	if (val) {
-		dev_dbg(dev, "gpio triggered after poll_wait\n");
-		pm_wakeup_event(dev, FPC_MAX_HAL_PROCESSING_TIME);
-		return POLLIN | POLLRDNORM;
 	}
 
 	/*


### PR DESCRIPTION
Fixes XA2 fingerprint sensor

From https://github.com/sonyxperiadev/kernel/pull/2017