### PR TITLE
Revert "fuse: don't mess with blocking signals"

### DIFF
--- a/fs/fuse/dev.c
+++ b/fs/fuse/dev.c
@@ -101,6 +101,19 @@ void fuse_request_free(struct fuse_req *req)
 	kmem_cache_free(fuse_req_cachep, req);
 }
 
+static void block_sigs(sigset_t *oldset)
+{
+	sigset_t mask;
+
+	siginitsetinv(&mask, sigmask(SIGKILL));
+	sigprocmask(SIG_BLOCK, &mask, oldset);
+}
+
+static void restore_sigs(sigset_t *oldset)
+{
+	sigprocmask(SIG_SETMASK, oldset, NULL);
+}
+
 void __fuse_get_request(struct fuse_req *req)
 {
 	atomic_inc(&req->count);
@@ -150,9 +163,15 @@ static struct fuse_req *__fuse_get_req(struct fuse_conn *fc, unsigned npages,
 	atomic_inc(&fc->num_waiting);
 
 	if (fuse_block_alloc(fc, for_background)) {
+		sigset_t oldset;
+		int intr;
+
+		block_sigs(&oldset);
+		intr = wait_event_interruptible_exclusive(fc->blocked_waitq,
+				!fuse_block_alloc(fc, for_background));
+		restore_sigs(&oldset);
 		err = -EINTR;
-		if (wait_event_killable_exclusive(fc->blocked_waitq,
-				!fuse_block_alloc(fc, for_background)))
+		if (intr)
 			goto out;
 	}
 	/* Matches smp_wmb() in fuse_set_initialized() */
@@ -451,9 +470,14 @@ static void request_wait_answer(struct fuse_conn *fc, struct fuse_req *req)
 	}
 
 	if (!test_bit(FR_FORCE, &req->flags)) {
+		sigset_t oldset;
+
 		/* Only fatal signals may interrupt this */
-		err = wait_event_killable(req->waitq,
+		block_sigs(&oldset);
+		err = wait_event_interruptible(req->waitq,
 					test_bit(FR_FINISHED, &req->flags));
+		restore_sigs(&oldset);
+
 		if (!err)
 			return;
 


### PR DESCRIPTION
This reverts commit 7d3a07fcb8a0d5c06718de14fb91fdf1ef20a0e2.

Fixes device suspend in Sailfish OS.