### PR TITLE
pn547: Add compat_ioctl method to support 32-bit calls

### DIFF
--- a/drivers/misc/pn547.c
+++ b/drivers/misc/pn547.c
@@ -441,6 +441,7 @@ static const struct file_operations pn547_dev_fops = {
 	.write = pn547_dev_write,
 	.open = pn547_dev_open,
 	.unlocked_ioctl = pn547_dev_ioctl,
+	.compat_ioctl = pn547_dev_ioctl
 };
 
 #ifdef CONFIG_OF


### PR DESCRIPTION
To allow 32-bit SFOS to talk to 64-bit pn547 driver.