### PR TITLE
(hybris) git: restore submodules to fix recurse cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "drivers/staging/wlan-qc/qca-wifi-host-cmn"]
+	path = drivers/staging/wlan-qc/qca-wifi-host-cmn
+	url = https://github.com/sonyxperiadev/vendor-qcom-opensource-wlan-qca-wifi-host-cmn
+[submodule "drivers/staging/wlan-qc/qcacld-3.0"]
+	path = drivers/staging/wlan-qc/qcacld-3.0
+	url = https://github.com/sonyxperiadev/vendor-qcom-opensource-wlan-qcacld-3.0
+[submodule "drivers/staging/wlan-qc/fw-api"]
+	path = drivers/staging/wlan-qc/fw-api
+	url = https://github.com/sonyxperiadev/vendor-qcom-opensource-wlan-fw-api


### PR DESCRIPTION
This fixes errors when this kernel repository is cloned with
--recurse-submodules, due to containing other git repos nested within,
but without .gitmodules file. The error git clone fails with is:

fatal: No url found for submodule path
'kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/fw-api' in .gitmodules

This is essential for use cases where this repository is a submodule itself,
and recursive cloning is the only policy used during the CI builds.