### PR TITLE
Disable usermode helper

### DIFF
--- a/arch/arm64/configs/aosp_edo_pdx203_defconfig
+++ b/arch/arm64/configs/aosp_edo_pdx203_defconfig
@@ -938,3 +938,7 @@ CONFIG_PM_AUTOSLEEP=y
 CONFIG_HARDEN_BRANCH_PREDICTOR=y
 
 CONFIG_WIREGUARD=y
+
+# Android mandates to use a user mode helper when the kernel has to call userspace
+# programs to handle things such as core dumps but we don't do that
+CONFIG_STATIC_USERMODEHELPER=n

--- a/arch/arm64/configs/aosp_edo_pdx206_defconfig
+++ b/arch/arm64/configs/aosp_edo_pdx206_defconfig
@@ -938,3 +938,7 @@ CONFIG_PM_AUTOSLEEP=y
 CONFIG_HARDEN_BRANCH_PREDICTOR=y
 
 CONFIG_WIREGUARD=y
+
+# Android mandates to use a user mode helper when the kernel has to call userspace
+# programs to handle things such as core dumps but we don't do that
+CONFIG_STATIC_USERMODEHELPER=n

--- a/arch/arm64/configs/aosp_lena_pdx213_defconfig
+++ b/arch/arm64/configs/aosp_lena_pdx213_defconfig
@@ -939,3 +939,7 @@ CONFIG_PM_AUTOSLEEP=y
 CONFIG_HARDEN_BRANCH_PREDICTOR=y
 
 CONFIG_WIREGUARD=y
+
+# Android mandates to use a user mode helper when the kernel has to call userspace
+# programs to handle things such as core dumps but we don't do that
+CONFIG_STATIC_USERMODEHELPER=n


### PR DESCRIPTION
- Merge upstream updates
  - Conflicts
    - `.gitignore`  - Upstream wanted to ignore the wlan-qc submodules
- Disable `CONFIG_STATIC_USERMODEHELPER`
  - Android mandates to use a user mode helper when the kernel has to call userspace
    programs to handle things such as core dumps but we don't do that.