### PR TITLE
Disable usermode helper

### DIFF
--- a/arch/arm64/configs/aosp_murray_pdx225_defconfig
+++ b/arch/arm64/configs/aosp_murray_pdx225_defconfig
@@ -1066,3 +1066,7 @@ CONFIG_INET_AH=y
 CONFIG_IP_NF_MATCH_RPFILTER=y
 CONFIG_QUOTA_NETLINK_INTERFACE=y
 CONFIG_INET6_AH=y
+
+# Android mandates to use a user mode helper when the kernel has to call userspace
+# programs to handle things such as core dumps but we don't do that
+CONFIG_STATIC_USERMODEHELPER=n

--- a/arch/arm64/configs/aosp_zambezi_pdx235_defconfig
+++ b/arch/arm64/configs/aosp_zambezi_pdx235_defconfig
@@ -1061,3 +1061,7 @@ CONFIG_INET_AH=y
 CONFIG_IP_NF_MATCH_RPFILTER=y
 CONFIG_QUOTA_NETLINK_INTERFACE=y
 CONFIG_INET6_AH=y
+
+# Android mandates to use a user mode helper when the kernel has to call userspace
+# programs to handle things such as core dumps but we don't do that
+CONFIG_STATIC_USERMODEHELPER=n


### PR DESCRIPTION
- Disable CONFIG_STATIC_USERMODEHELPER
  - Android mandates to use a user mode helper when the kernel has to call userspace
    programs to handle things such as core dumps but we don't do that.