### PR TITLE
Update hybris-sony-aosp/LA.UM.9.16.r1 from Sony upstream

### DIFF
--- a/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
@@ -192,12 +192,6 @@
 	};
 };
 
-&qupv3_se8_i2c_sleep {
-	config {
-		drive-strength = <0>;
-	};
-};
-
 &qupv3_se0_i2c {
 	nq@28 {
 		status = "disabled";


### PR DESCRIPTION
dts: somc: Zambezi: Restore default qupv3_se8_i2c_sleep drive-strength